### PR TITLE
SPI bus sharing improvements on JS side

### DIFF
--- a/index.js
+++ b/index.js
@@ -237,10 +237,10 @@ Audio.prototype._softReset = function(callback) {
       this._writeSciRegister16(SCI_MODE, mode | MODE_SM_RESET, function(err) {
         if (err) { return callback && callback(err); }
         else {
-          while (!this.MP3_DREQ);
+          while (!this.MP3_DREQ.read()) ;   // wait for ready
           this._writeSciRegister16(SCI_MODE, 0x4800, callback);
         }
-      });
+      }.bind(this));
     }
   }.bind(this))
 }

--- a/index.js
+++ b/index.js
@@ -277,12 +277,6 @@ Audio.prototype._setClockSpeeds = function(callback) {
 
 }
 
-Audio.prototype._SPItransferByte = function(byte, callback) {
-  this._SPItransferArray([byte], function(err, ret) {
-    callback && callback(err, ret[0]);
-  });
-}
-
 Audio.prototype._SPItransferArray = function(array, callback) {
   this.spi.transfer(new Buffer(array), function(err, ret) {
     return callback && callback(err, ret);

--- a/index.js
+++ b/index.js
@@ -292,25 +292,15 @@ Audio.prototype._SPItransferArray = function(array, callback) {
 //Read the 16-bit value of a VS10xx register
 Audio.prototype._readSciRegister16 = function(addressbyte, callback) {
   this._once_dreq_ready(function () {
+    // TODO: we need to make sure SPI is locked before asserting XCS
     this.MP3_XCS.low(); //Select control
-
     //SCI consists of instruction byte, address byte, and 16-bit data word.
-    this._SPItransferByte(0x03, function(err) {
-      this._SPItransferByte(addressbyte, function(err) {
-        this._SPItransferByte(0xFF, function(err, response1) {
-          this._once_dreq_ready(function () {
-            this._SPItransferByte(0xFF, function(err, response2) {
-              this._once_dreq_ready(function () {
-                this.MP3_XCS.high(); //Deselect Control
-                var result = (response1 << 8) + response2;
-                callback && callback(err, result);
-              }.bind(this));
-            }.bind(this));
-          }.bind(this));
-        }.bind(this));
-      }.bind(this));
+    this._SPItransferArray([0x03, addressbye, 0xFF, 0xFF], function(err, response) {
+      this.MP3_XCS.high(); //Deselect Control
+      var result = (response[2] << 8) + response[3];
+      callback && callback(err, result);
     }.bind(this));
-  }.bind(this));
+  });
 }
 
 Audio.prototype._writeSciRegister = function(addressbyte, highbyte, lowbyte, callback) {

--- a/index.js
+++ b/index.js
@@ -305,17 +305,12 @@ Audio.prototype._readSciRegister16 = function(addressbyte, callback) {
 
 Audio.prototype._writeSciRegister = function(addressbyte, highbyte, lowbyte, callback) {
   this._once_dreq_ready(function () {
+    // TODO: first acquire SPI bus lock
     this.MP3_XCS.low(); //Select control
-
     //SCI consists of instruction byte, address byte, and 16-bit data word.
     this._SPItransferArray([0x02, addressbyte, highbyte, lowbyte], function(err) {
-      if (err) {
-        return callback && callback(err);
-      }
-      else this._once_dreq_ready(function () {
-        this.MP3_XCS.high(); //Deselect Control
-        callback && callback();
-      }.bind(this));
+      this.MP3_XCS.high(); //Deselect Control
+      callback && callback();
     }.bind(this));
   }.bind(this));
 }


### PR DESCRIPTION
This cleans up and simplifies a lot of the initialization (and other JS control) code path so it doesn't set the SPI select lines outside of "owning" the bus.

The main lingering concerns I have are:
- the SPI interface `.initialize` call is now a no-op and should just get cleaned up out of this module
- the SPI speed for controlSPI seems to affect data SPI (if left at default playback gets choppy); perhaps the C code is not initializing its own SPI communication or is assuming the JS code initialize calls are doing it for them
- generally the playback lock stuff doesn't seem quite right on the JS side, but haven't quite traced through how it's supposed to be working yet
- and of course the C shim side doesn't share locks yet